### PR TITLE
Separate AWS auth

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,11 +5,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
+      - name: AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Self test
         id: selftest
         uses: stumason/codebuild-logs@master
         env:
-          aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: ${{ secrets.AWS_REGION }}
           codebuild-project-name: ${{ secrets.PROJECT }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,12 +5,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Lint
         run: |

--- a/action.yml
+++ b/action.yml
@@ -2,12 +2,6 @@ name: "project-codebuild-logs"
 description: "Get last codebuild event logs for project"
 author: "Stu Mason"
 inputs:
-  aws-access-key-id:
-    description: "AWS key"
-    default: null
-  aws-secret-access-key:
-    description: "AWS Secret"
-    default: null
   aws-region:
     description: "Codebuild Project AWS region"
     default: null

--- a/main.py
+++ b/main.py
@@ -5,16 +5,12 @@ from datetime import datetime
 
 
 def main():
-    key = os.environ["aws-access-key-id"]
-    secret = os.environ["aws-secret-access-key"]
     region = os.environ["aws-region"]
     project = os.environ["codebuild-project-name"]
 
     codebuild = boto3.client(
         'codebuild',
-        region_name=region,
-        aws_access_key_id=key,
-        aws_secret_access_key=secret,
+        region_name=region
     )
 
     response = codebuild.list_builds_for_project(
@@ -26,9 +22,7 @@ def main():
 
     logs = boto3.client(
         'logs',
-        region_name=region,
-        aws_access_key_id=key,
-        aws_secret_access_key=secret,
+        region_name=region
     )
 
     response = logs.get_log_events(


### PR DESCRIPTION
Removing AWS auth from this package means CodeBuild will look for AWS credentials file.

This can be supplied in a separate Github Action either by AWS key/secret or by OIDC to give flexibility