### PR TITLE
Use proper python base image to build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM python:3-slim AS builder
+FROM python:3.10-slim AS builder
 ADD . /app
 WORKDIR /app
 
-# We are installing a dependency here directly into our app source dir
+# Install dependencies
 RUN pip install --target=/app -r requirements.txt
-
-# A distroless container image with Python and some basics like SSL certificates
-# https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/python3-debian10
-COPY --from=builder /app /app
-WORKDIR /app
-ENV PYTHONPATH /app
-CMD ["/app/main.py"]
+ENV PYTHONPATH=/app
+CMD ["python", "/app/main.py"]


### PR DESCRIPTION
Currently build are failing because of the `distroless` image. Updating it to use the base image itself.